### PR TITLE
Explicit memory management of actions

### DIFF
--- a/G4HiveActions/ActionToolBase.h
+++ b/G4HiveActions/ActionToolBase.h
@@ -1,6 +1,9 @@
 #ifndef G4HIVEACTIONS_ACTIONTOOLBASE_H
 #define G4HIVEACTIONS_ACTIONTOOLBASE_H
 
+// System includes
+#include <memory>
+
 // Framework includes
 #include "AthenaBaseComps/AthAlgTool.h"
 
@@ -42,8 +45,9 @@ namespace g4hive
       {
         ActionType* action = m_actions.get();
         if(!action){
-          action = makeAction();
-          m_actions.set(action);
+          auto uniqueAction = makeAction();
+          m_actions.set(std::move(uniqueAction));
+          action = uniqueAction.get();
         }
         return action;
       }
@@ -52,7 +56,7 @@ namespace g4hive
 
       /// @brief Abstract method to create a custom action on demand.
       /// This method must be implemented by the concrete action tool.
-      virtual ActionType* makeAction() = 0;
+      virtual std::unique_ptr<ActionType> makeAction() = 0;
 
     private:
 

--- a/G4HiveActions/ThreadActionHolder.h
+++ b/G4HiveActions/ThreadActionHolder.h
@@ -1,7 +1,12 @@
 #ifndef G4HIVEACTIONS_THREADACTIONHOLDER_H
 #define G4HIVEACTIONS_THREADACTIONHOLDER_H
 
+// System includes
 #include <thread>
+#include <memory>
+#include <utility>
+
+// Other includes
 #include "tbb/concurrent_unordered_map.h"
 
 namespace g4hive
@@ -10,7 +15,10 @@ namespace g4hive
   /// @brief A thread-local storage wrapper for the user actions.
   ///
   /// This container is implemented as a wrapper for a concurrent map
-  /// keyed by std thread ID. It is thus fully thread-safe (I hope).
+  /// keyed by std thread ID. It is thus fully thread-safe (in theory).
+  ///
+  /// The thread-local storage is cleared in the destructor for now, at least
+  /// until TBB's concurrent containers support move semantics and unique_ptr.
   ///
   /// @author Steve Farrell <Steven.Farrell@cern.ch>
   ///
@@ -20,23 +28,34 @@ namespace g4hive
 
     public:
 
-      /// @brief Get the object of the current thread.
+      /// @brief Destructor will clean up the thread-local storage.
+      /// Would prefer to do this automatically with unique_ptr.
+      ~ThreadActionHolder() {
+        for(auto mapPair : m_threadMap){
+          delete mapPair.second;
+        }
+        m_threadMap.clear();
+      }
+
+      /// Get the object of the current thread.
       ActionType* get() {
         auto mapPair = m_threadMap.find( std::this_thread::get_id() );
         if(mapPair == m_threadMap.end()) return nullptr;
         return mapPair->second;
       }
 
-      /// @brief Assign the object of the current thread.
-      void set(ActionType* action) {
+      /// Assign the object of the current thread.
+      /// Memory management must be handled manually for now.
+      void set(std::unique_ptr<ActionType> action) {
         const auto tid = std::this_thread::get_id();
-        m_threadMap.insert( std::make_pair(tid, action) );
+        m_threadMap.insert( std::make_pair(tid, action.release()) );
       }
 
     private:
 
       typedef std::thread::id ThreadMapKey_t;
       typedef ActionType* ThreadMapVal_t;
+      //typedef std::unique_ptr<ActionType> ThreadMapVal_t; // not supported
       typedef std::hash<ThreadMapKey_t> ThreadMapHash_t;
       typedef tbb::concurrent_unordered_map 
       < ThreadMapKey_t, ThreadMapVal_t, ThreadMapHash_t > ThreadMap_t;

--- a/cmt/requirements
+++ b/cmt/requirements
@@ -5,6 +5,7 @@ use GaudiInterface      GaudiInterface-*        External
 use AthenaBaseComps     AthenaBaseComps-*       Control
 
 private
+use CxxUtils            CxxUtils-*              Control
 use Geant4              Geant4-*                External
 end_private
 

--- a/src/ExampleMultiActionTool.cxx
+++ b/src/ExampleMultiActionTool.cxx
@@ -1,4 +1,4 @@
-// Local includes
+#include "CxxUtils/make_unique.h"
 #include "ExampleMultiActionTool.h"
 
 namespace g4hive
@@ -17,10 +17,11 @@ namespace g4hive
   //---------------------------------------------------------------------------
   // Create the action on demand
   //---------------------------------------------------------------------------
-  ExampleMultiAction* ExampleMultiActionTool::makeAction()
+  std::unique_ptr<ExampleMultiAction> ExampleMultiActionTool::makeAction()
   {
     // Configure it here also
-    return new ExampleMultiAction();
+    auto action = CxxUtils::make_unique<ExampleMultiAction>();
+    return std::move(action);
   }
 
 } // namespace g4hive

--- a/src/ExampleMultiActionTool.h
+++ b/src/ExampleMultiActionTool.h
@@ -46,7 +46,7 @@ namespace g4hive
     private:
 
       /// Create an action on demand for this thread.
-      ExampleMultiAction* makeAction() override final;
+      std::unique_ptr<ExampleMultiAction> makeAction() override final;
 
   }; // class ExampleMultiActionTool
 

--- a/src/ExampleSteppingActionTool.cxx
+++ b/src/ExampleSteppingActionTool.cxx
@@ -1,4 +1,4 @@
-// Local includes
+#include "CxxUtils/make_unique.h"
 #include "ExampleSteppingActionTool.h"
 
 namespace g4hive
@@ -17,9 +17,12 @@ namespace g4hive
   //---------------------------------------------------------------------------
   // Create the action on request
   //---------------------------------------------------------------------------
-  ExampleSteppingAction* ExampleSteppingActionTool::makeAction()
+  std::unique_ptr<ExampleSteppingAction>
+  ExampleSteppingActionTool::makeAction()
   {
-    return new ExampleSteppingAction();
+    // Configure it here also
+    auto action = CxxUtils::make_unique<ExampleSteppingAction>();
+    return std::move(action);
   }
 
 }

--- a/src/ExampleSteppingActionTool.h
+++ b/src/ExampleSteppingActionTool.h
@@ -32,7 +32,7 @@ namespace g4hive
     protected:
 
       /// Create an action for this thread
-      ExampleSteppingAction* makeAction() override final;
+      std::unique_ptr<ExampleSteppingAction> makeAction() override final;
 
   }; // class ExampleSteppingActionTool
 

--- a/src/UserActionSvc.cxx
+++ b/src/UserActionSvc.cxx
@@ -1,4 +1,4 @@
-// Local includes
+#include "CxxUtils/make_unique.h"
 #include "UserActionSvc.h"
 
 namespace g4hive
@@ -32,61 +32,56 @@ namespace g4hive
   StatusCode UserActionSvc::initializeActions()
   {
     // Initialize the ATLAS stepping action.
-    G4AtlasSteppingAction* stepAction = m_steppingActions.get();
-    if(stepAction) {
+    if(m_steppingActions.get()) {
       ATH_MSG_ERROR("Stepping action already exists for current thread!");
       return StatusCode::FAILURE;
     }
-    stepAction = new G4AtlasSteppingAction;
-    m_steppingActions.set(stepAction);
+    auto stepAction = CxxUtils::make_unique<G4AtlasSteppingAction>();
 
     // Assign stepping plugins
     for(auto stepTool : m_steppingActionTools){
       ISteppingAction* stepPlugin = stepTool->getSteppingAction();
       stepAction->addAction(stepPlugin);
     }
+    m_steppingActions.set( std::move(stepAction) );
 
     // Initialize the ATLAS tracking action.
-    G4AtlasTrackingAction* trackAction = m_trackingActions.get();
-    if(trackAction) {
+    if(m_trackingActions.get()) {
       ATH_MSG_ERROR("Tracking action already exists for current thread!");
       return StatusCode::FAILURE;
     }
-    trackAction = new G4AtlasTrackingAction;
-    m_trackingActions.set(trackAction);
+    auto trackAction = CxxUtils::make_unique<G4AtlasTrackingAction>();
 
     // Assign pre-tracking plugins
     for(auto preTrackTool : m_preTrackingActionTools){
       IPreTrackingAction* preTrackPlugin = preTrackTool->getPreTrackingAction();
       trackAction->addPreTrackAction(preTrackPlugin);
     }
-
     // Assign post-tracking plugins
     for(auto postTrackTool : m_postTrackingActionTools){
       IPostTrackingAction* postTrackPlugin = postTrackTool->getPostTrackingAction();
       trackAction->addPostTrackAction(postTrackPlugin);
     }
+    m_trackingActions.set( std::move(trackAction) );
 
     // Initialize the ATLAS event action.
-    G4AtlasEventAction* eventAction = m_eventActions.get();
-    if(eventAction) {
+    if(m_eventActions.get()) {
       ATH_MSG_ERROR("Event action already exists for current thread!");
       return StatusCode::FAILURE;
     }
-    eventAction = new G4AtlasEventAction;
-    m_eventActions.set(eventAction);
+    auto eventAction = CxxUtils::make_unique<G4AtlasEventAction>();
 
     // Assign begin-event plugins
     for(auto beginEventTool : m_beginEventActionTools){
       IBeginEventAction* beginEventPlugin = beginEventTool->getBeginEventAction();
       eventAction->addBeginEventAction(beginEventPlugin);
     }
-
     // Assign end-event plugins
     for(auto endEventTool : m_endEventActionTools){
       IEndEventAction* endEventPlugin = endEventTool->getEndEventAction();
       eventAction->addEndEventAction(endEventPlugin);
     }
+    m_eventActions.set( std::move(eventAction) );
 
     return StatusCode::SUCCESS;
   }


### PR DESCRIPTION
Using unique_ptr where possible to explicitly communicate object ownership. Unfortunately, the tbb concurrent_unordered_map doesn't support move semantics so I cannot store unique_ptrs directly. I am thus instead deleting the objects manually in the ThreadActionHolder destructor.
